### PR TITLE
Correct the inclusion and usage of Eigen in CMakeLists.txt

### DIFF
--- a/ros_package_template/CMakeLists.txt
+++ b/ros_package_template/CMakeLists.txt
@@ -51,7 +51,7 @@ include_directories(
 #  ${Boost_INCLUDE_DIRS}
 )
 
-include(${EIGEN3_USE_FILE})
+#include(${EIGEN3_USE_FILE})
 
 ## Declare a cpp library
 add_library(${PROJECT_NAME}_core

--- a/ros_package_template/CMakeLists.txt
+++ b/ros_package_template/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.10)
 project(ros_package_template)
 
+## Use C++14
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 ## By adding -Wall and -Werror, the compiler does not ignore warnings anymore,
 ## enforcing cleaner code.
 add_definitions(-Wall -Werror)
@@ -14,8 +18,8 @@ find_package(catkin REQUIRED
 )
 
 ## Find system libraries
-#find_package(Eigen3 REQUIRED)
-#find_package(Boost REQUIRED)
+find_package(Eigen3 REQUIRED)
+find_package(Boost REQUIRED)
 
 ###################################
 ## catkin specific configuration ##
@@ -29,14 +33,20 @@ find_package(catkin REQUIRED
 catkin_package(
   INCLUDE_DIRS
     include
+    ## This is only necessary because Eigen3 sets a non-standard EIGEN3_INCLUDE_DIR variable
+    ${EIGEN3_INCLUDE_DIR}
   LIBRARIES
     ${PROJECT_NAME}_core
   CATKIN_DEPENDS
     roscpp
     sensor_msgs
-#  DEPENDS
-#    Boost
-#    EIGEN3
+  DEPENDS
+  ## find_package(Eigen3) provides a non standard EIGEN3_INCLUDE_DIR instead of Eigen3_INCLUDE_DIRS.
+  ## Therefore, the DEPEND does not work as expected and we need to add the directory to the INCLUDE_DIRS
+  # Eigen3
+
+  ## Boost is not part of the DEPENDS since it is only used in source files,
+  ## Dependees do not depend on Boost when they depend on this package.
 )
 
 ###########
@@ -48,10 +58,11 @@ catkin_package(
 include_directories(
   include
   ${catkin_INCLUDE_DIRS}
-#  ${Boost_INCLUDE_DIRS}
+  # Set manually because Eigen sets a non standard INCLUDE DIR
+  ${EIGEN3_INCLUDE_DIR}
+  # Set because Boost is an internal dependency, not transitive.
+  ${Boost_INCLUDE_DIRS}
 )
-
-#include(${EIGEN3_USE_FILE})
 
 ## Declare a cpp library
 add_library(${PROJECT_NAME}_core

--- a/ros_package_template/CMakeLists.txt
+++ b/ros_package_template/CMakeLists.txt
@@ -29,7 +29,6 @@ find_package(catkin REQUIRED
 catkin_package(
   INCLUDE_DIRS
     include
-#    ${EIGEN3_INCLUDE_DIR}
   LIBRARIES
     ${PROJECT_NAME}_core
   CATKIN_DEPENDS
@@ -37,6 +36,7 @@ catkin_package(
     sensor_msgs
 #  DEPENDS
 #    Boost
+#    EIGEN3
 )
 
 ###########
@@ -48,9 +48,10 @@ catkin_package(
 include_directories(
   include
   ${catkin_INCLUDE_DIRS}
-#  ${EIGEN3_INCLUDE_DIR}
 #  ${Boost_INCLUDE_DIRS}
 )
+
+include(${EIGEN3_USE_FILE})
 
 ## Declare a cpp library
 add_library(${PROJECT_NAME}_core

--- a/ros_package_template/include/ros_package_template/Algorithm.hpp
+++ b/ros_package_template/include/ros_package_template/Algorithm.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
-#include <cstddef>
+#include <memory>
+
+#include <Eigen/Core>
 
 namespace ros_package_template {
 
@@ -27,18 +29,24 @@ class Algorithm
   void addData(const double data);
 
   /*!
+   * Add multiple measurements as once.
+   * @param data new data.
+   */
+  void addData(const Eigen::VectorXd& data);
+
+  /*!
    * Get the computed average of the data.
    * @return the average of the data.
    */
   double getAverage() const;
 
  private:
+ 
+  //! Forward declared structure that will contain the data
+  struct Data;
 
-  //! Internal variable to hold the current average.
-  double average_;
-
-  //! Number of measurements taken.
-  size_t nMeasurements_;
+  //! Pointer to data (pimpl)
+  std::unique_ptr<Data> data_;
 };
 
 } /* namespace */

--- a/ros_package_template/package.xml
+++ b/ros_package_template/package.xml
@@ -8,12 +8,13 @@
   <url type="website">https://github.com/ethz-asl/ros_best_practices</url>
   <url type="bugtracker">https://github.com/ethz-asl/ros_best_practices/issues</url>
   <author email="pfankhauser@anybotics.com">Peter Fankhauser</author>
-  
+
+  <!-- buildtool_depend: dependencies of the build process -->
   <buildtool_depend>catkin</buildtool_depend>
-  
-  <!--<build_depend>eigen</build_depend>-->
-  <!--<build_export_depend>eigen</build_export_depend>-->
-  <!--<depend>boost</depend>-->
+  <!-- build_depend: dependencies only used in source files -->
+  <build_depend>boost</build_depend>
+  <!-- depend: build, export, and execution dependency -->
+  <depend>eigen</depend>
   <depend>roscpp</depend>
   <depend>sensor_msgs</depend>
 

--- a/ros_package_template/src/Algorithm.cpp
+++ b/ros_package_template/src/Algorithm.cpp
@@ -1,26 +1,39 @@
 #include "ros_package_template/Algorithm.hpp"
 
+#include <utility>
+
+#include <boost/accumulators/accumulators.hpp>
+#include <boost/accumulators/statistics/mean.hpp>
+#include <boost/accumulators/statistics/count.hpp>
+
 namespace ros_package_template {
 
-Algorithm::Algorithm()
-    : average_(0.0),
-      nMeasurements_(0)
-{
+using namespace boost::accumulators;
+
+struct Algorithm::Data {
+  accumulator_set<double, features<tag::mean, tag::count>> acc;
+};
+
+Algorithm::Algorithm() {
+  data_ = std::make_unique<Data>();
 }
 
-Algorithm::~Algorithm()
-{
-}
+Algorithm::~Algorithm() = default;
 
 void Algorithm::addData(const double data)
 {
-  average_ = (nMeasurements_ * average_ + data) / (nMeasurements_ + 1);
-  nMeasurements_++;
+  data_->acc(data);
+}
+
+void Algorithm::addData(const Eigen::VectorXd& data)
+{
+  for(auto i = 0; i < data.size(); ++i)
+    addData(data[i]);
 }
 
 double Algorithm::getAverage() const
 {
-  return average_;
+  return count(data_->acc) ? mean(data_->acc) : 0;
 }
 
 } /* namespace */

--- a/ros_package_template/test/AlgorithmTest.cpp
+++ b/ros_package_template/test/AlgorithmTest.cpp
@@ -6,6 +6,8 @@
 // STD
 #include <vector>
 
+#include <Eigen/Core>
+
 using namespace ros_package_template;
 
 TEST(Algorithm, getWithoutSet)
@@ -22,6 +24,18 @@ TEST(Algorithm, singleDataPoint)
   algorithm.addData(inputData);
   const double average = algorithm.getAverage();
   EXPECT_NEAR(inputData, average, 1e-10);
+}
+
+TEST(Algorithm, singleDataVector)
+{
+  const double inputValue = 100.0 * (double)rand() / RAND_MAX;
+  Algorithm algorithm;
+  Eigen::VectorXd inputData;
+  inputData.resize(2);
+  inputData << inputValue, 3*inputValue;
+  algorithm.addData(inputData);
+  const double average = algorithm.getAverage();
+  EXPECT_NEAR(2*inputValue, average, 1e-10);
 }
 
 TEST(Algorithm, multipleDataPoints)


### PR DESCRIPTION
Specifying `${EIGEN3_INCLUDE_DIR}` as an explicit catkin_package INCLUDE_DIR is not as good idea as putting it as a DEPENDS package. That will do the same thing and, moreover, is future-proof. Further, it also adds required compiler definitions, which you've forgot to do here (and I think lots of people would). This can have disastrous consequences if you change some flags that alter memory layout of Eigen objects.

Also, adding the include directory via a UseEigen3 file is more future-proof.