### PR TITLE
Eigen is not a exec_depend.

### DIFF
--- a/ros_package_template/package.xml
+++ b/ros_package_template/package.xml
@@ -11,7 +11,8 @@
   
   <buildtool_depend>catkin</buildtool_depend>
   
-  <!--<depend>eigen</depend>-->
+  <!--<build_depend>eigen</build_depend>-->
+  <!--<build_export_depend>eigen</build_export_depend>-->
   <!--<depend>boost</depend>-->
   <depend>roscpp</depend>
   <depend>sensor_msgs</depend>


### PR DESCRIPTION
Eigen has no libraries, so it is not a runtime dependency.